### PR TITLE
Add `organization_ids` property

### DIFF
--- a/src/Zammad.Client/Resources/User.cs
+++ b/src/Zammad.Client/Resources/User.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 
@@ -12,6 +12,9 @@ namespace Zammad.Client.Resources
 
         [JsonProperty("organization_id")]
         public int? OrganizationId { get; set; }
+
+        [JsonProperty("organization_ids")]
+        public int[] SecondaryOrganizationIds { get; set; }
 
         [JsonProperty("login")]
         public string Login { get; set; }


### PR DESCRIPTION
Fixes #47 

zammad offers the `organization_ids` property which contains the IDs of the secondary organizations.
```json
{
    "id": 1463,
    "organization_id": 1058 /* Test-Organization-One */,
    "login": "nm@lis-gmbh.com",
    "firstname": "Necati",
    "lastname": "Meral",
    "email": "nm@lis-gmbh.com",
    // ...
    "organization_ids": [
        1059 /* Test-Organization-Two */,
        1060 /* Test-Organization-Three */
    ],
    "authorization_ids": [],
    "karma_user_ids": [],
    "group_ids": {}
}
```

![image](https://user-images.githubusercontent.com/7882753/184082937-e180da5c-6619-4d69-9dd6-a6f3e4f5c4f5.png)
